### PR TITLE
Task/temp 114 copy right point

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2016 Raizlabs, inc.
+Copyright (c) 2016 Rightpoint, inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PRODUCTNAME/Dangerfile
+++ b/PRODUCTNAME/Dangerfile
@@ -40,7 +40,7 @@ swiftlint.lint_files inline_mode: true
 # Getting artifact URLs from CircleCI
 
 # You must set up the CIRCLE_API_TOKEN manually using these instructions
-# https://github.com/Raizlabs/ios-template/tree/master/PRODUCTNAME#danger
+# https://github.com/Rightpoint/ios-template#danger
 token = ENV['CIRCLE_API_TOKEN']
 # These are already in the Circle environment
 # https://circleci.com/docs/2.0/env-vars/#build-specific-environment-variables
@@ -83,7 +83,7 @@ if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
     message "Screenshots in progress..."
   end
 else
-  warn "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Raizlabs/circleci_artifact#getting-started) is not set, or Danger is not running on CircleCI."
+  warn "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Rightpoint/circleci_artifact#getting-started) is not set, or Danger is not running on CircleCI."
 end
 
 # Test Reporting

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppDelegate.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppDelegate.swift
@@ -2,8 +2,8 @@
 //  AppDelegate.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/Analytics/Analytics.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/Analytics/Analytics.swift
@@ -2,8 +2,8 @@
 //  Analytics.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 1/13/17.
-//  Copyright © 2017 ORGANIZATION All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/Analytics/AnalyticsPageNames.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/Analytics/AnalyticsPageNames.swift
@@ -2,8 +2,8 @@
 //  AnalyticsPageNames.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 1/13/17.
-//  Copyright © 2017 ORGANIZATION All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/Analytics/GoogleAnalytics.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/Analytics/GoogleAnalytics.swift
@@ -2,8 +2,8 @@
 //  GoogleAnalytics.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 1/13/17.
-//  Copyright © 2017 ORGANIZATION All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/AnalyticsConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/AnalyticsConfiguration.swift
@@ -2,8 +2,8 @@
 //  AnalyticsConfiguration.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Swiftilities

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/AppLifecycle.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/AppLifecycle.swift
@@ -2,8 +2,8 @@
 //  AppLifecycleConfigurable.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/CrashlyticsConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/CrashlyticsConfiguration.swift
@@ -2,8 +2,8 @@
 //  CrashlyticsConfiguration.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Fabric

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/DebugMenuConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/DebugMenuConfiguration.swift
@@ -2,8 +2,8 @@
 //  DebugMenuConfiguration.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/InstabugConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/InstabugConfiguration.swift
@@ -2,8 +2,8 @@
 //  InstabugConfiguration.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Instabug

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/LoggingConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/LoggingConfiguration.swift
@@ -2,8 +2,8 @@
 //  LoggingConfiguration.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/StatusBarConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/StatusBarConfiguration.swift
@@ -2,8 +2,8 @@
 //  StatusBarConfiguration.swift
 //  PRODUCTNAME
 //
-//  Created by Zev Eisenberg on 4/3/18.
-//  Copyright © 2018 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 #if targetEnvironment(simulator) && DEBUG

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/Appearance/Appearance.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/Appearance/Appearance.swift
@@ -2,8 +2,8 @@
 //  Appearance.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/Appearance/StringStyle+PRODUCTNAME.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/Appearance/StringStyle+PRODUCTNAME.swift
@@ -2,8 +2,8 @@
 //  StringStyle+PRODUCTNAME.swft
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/Debug/DebugMenu.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/Debug/DebugMenu.swift
@@ -2,8 +2,8 @@
 //  DebugMenu.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 10/25/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Swiftilities

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/Debug/DebugMenuViewController.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/Debug/DebugMenuViewController.swift
@@ -2,8 +2,8 @@
 //  DebugMenuViewController.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 10/26/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/Debug/DebugTextStyleViewController.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/Debug/DebugTextStyleViewController.swift
@@ -2,8 +2,8 @@
 //  DebugTextStyleViewController.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 10/25/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Behaviors/HideBackButtonTextBehavior.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Behaviors/HideBackButtonTextBehavior.swift
@@ -2,8 +2,8 @@
 //  HideBackButtonTextBehavior.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 7/7/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Swiftilities

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Behaviors/ModalDismissBehavior.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Behaviors/ModalDismissBehavior.swift
@@ -2,8 +2,8 @@
 //  ModalDismissBehavior.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 7/7/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Swiftilities

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Protocols/Actionable.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Protocols/Actionable.swift
@@ -2,8 +2,8 @@
 //  Actionable.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/8/18.
-//  Copyright © 2018 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 protocol Actionable: class {

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/SimpleTableCellItem.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/SimpleTableCellItem.swift
@@ -2,8 +2,8 @@
 //  SimpleTableCellItem.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 10/26/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/TableCellItem.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/TableCellItem.swift
@@ -2,8 +2,8 @@
 //  TableCellItem.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 7/10/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/TableDataSource.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/TableDataSource.swift
@@ -2,8 +2,8 @@
 //  TableDataSource.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 6/6/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Anchorage

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/TableSection.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/TableSection.swift
@@ -2,8 +2,8 @@
 //  TableSection.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 6/6/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/TableViewCellRepresentable.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/TableViewCellRepresentable.swift
@@ -2,8 +2,8 @@
 //  TableViewCellRepresentable.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 6/6/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/ViewRepresentable.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Representable/ViewRepresentable.swift
@@ -2,10 +2,10 @@
 //  ViewRepresentable.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 6/5/17.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
-//
 public protocol ViewRepresentable: AnyViewRepresentable {
     associatedtype View: UIView
     func makeView() -> View

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Views/ControlContainable.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Views/ControlContainable.swift
@@ -2,8 +2,8 @@
 //  ControlContainable.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 7/7/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAME/Components/Views/TableViewContainerCell.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Components/Views/TableViewContainerCell.swift
@@ -2,8 +2,8 @@
 //  TableViewContainerCell.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 6/6/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Anchorage

--- a/PRODUCTNAME/app/PRODUCTNAME/Coordinators/AppCoordinator.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Coordinators/AppCoordinator.swift
@@ -2,8 +2,8 @@
 //  AppCoordinator.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/24/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Coordinators/AuthCoordinator.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Coordinators/AuthCoordinator.swift
@@ -2,8 +2,8 @@
 //  AuthCoordinator.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/24/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Coordinators/ContentCoordinator.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Coordinators/ContentCoordinator.swift
@@ -2,8 +2,8 @@
 //  ContentCoordinator.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/27/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Coordinators/Coordinator.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Coordinators/Coordinator.swift
@@ -2,8 +2,8 @@
 //  Coordinator.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/24/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Coordinators/OnboardingCoordinator.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Coordinators/OnboardingCoordinator.swift
@@ -2,8 +2,8 @@
 //  OnboardingCoordinator.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/27/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Coordinators/SignInCoordinator.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Coordinators/SignInCoordinator.swift
@@ -2,8 +2,8 @@
 //  SignInCoordinator.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/27/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Extensions/UIColor+Extensions.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Extensions/UIColor+Extensions.swift
@@ -2,8 +2,8 @@
 //  UIColor+Extensions.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/29/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Resources/Color.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Resources/Color.swift
@@ -2,8 +2,8 @@
 //  Color.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/29/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 enum Color {

--- a/PRODUCTNAME/app/PRODUCTNAME/Resources/PRODUCTNAME-Bridging-Header.h
+++ b/PRODUCTNAME/app/PRODUCTNAME/Resources/PRODUCTNAME-Bridging-Header.h
@@ -2,8 +2,8 @@
 //  PRODUCTNAME-Bridging-Header.h
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/20/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 // EXTERNAL

--- a/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/AppStore.xcconfig
+++ b/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/AppStore.xcconfig
@@ -2,8 +2,8 @@
 //  AppStore.xcconfig
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 #include "PRODUCTNAME/Resources/xcconfig/Raizlabs-Account.xcconfig"

--- a/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Debug.xcconfig
+++ b/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Debug.xcconfig
@@ -2,8 +2,8 @@
 //  Debug.xcconfig
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 #include "PRODUCTNAME/Resources/xcconfig/Raizlabs-Account.xcconfig"

--- a/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Develop.xcconfig
+++ b/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Develop.xcconfig
@@ -2,8 +2,8 @@
 //  Develop.xcconfig
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 #include "PRODUCTNAME/Resources/xcconfig/Raizlabs-Account.xcconfig"

--- a/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Global.xcconfig
+++ b/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Global.xcconfig
@@ -2,8 +2,8 @@
 //  Global.xcconfig
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 BUILD_NUMBER=1

--- a/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Raizlabs-Account.xcconfig
+++ b/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Raizlabs-Account.xcconfig
@@ -2,8 +2,8 @@
 //  Raizlabs-Account.xcconfig
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 // Any keys that should be available to the application should be added here, and then

--- a/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Sprint.xcconfig
+++ b/PRODUCTNAME/app/PRODUCTNAME/Resources/xcconfig/Sprint.xcconfig
@@ -2,8 +2,8 @@
 //  Sprint.xcconfig
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 #include "PRODUCTNAME/Resources/xcconfig/Raizlabs-Account.xcconfig"

--- a/PRODUCTNAME/app/PRODUCTNAME/Screens/ContentTabBarViewController.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Screens/ContentTabBarViewController.swift
@@ -2,8 +2,8 @@
 //  ContentTabBarViewController.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/20/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import UIKit

--- a/PRODUCTNAME/app/PRODUCTNAME/Screens/Onboarding/OnboardingPageViewController.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Screens/Onboarding/OnboardingPageViewController.swift
@@ -2,8 +2,8 @@
 //  OnboardingPageViewController.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/29/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Anchorage

--- a/PRODUCTNAME/app/PRODUCTNAME/Screens/Onboarding/OnboardingSamplePageViewController.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Screens/Onboarding/OnboardingSamplePageViewController.swift
@@ -2,8 +2,8 @@
 //  OnboardingSamplePageViewController.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/29/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Anchorage

--- a/PRODUCTNAME/app/PRODUCTNAME/Screens/Onboarding/OnboardingSamplePageViewModel.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Screens/Onboarding/OnboardingSamplePageViewModel.swift
@@ -2,8 +2,8 @@
 //  OnboardingSamplePageViewModel.swift
 //  PRODUCTNAME
 //
-//  Created by Connor Neville on 4/5/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 struct OnboardingSamplePageViewModel {

--- a/PRODUCTNAME/app/PRODUCTNAME/Utilities/ProcessInfo+Utilities.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Utilities/ProcessInfo+Utilities.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension ProcessInfo {
 
-    static let uiTestsKey = "com.raizlabs.uiTests"
+    static let uiTestsKey = "com.rightpoint.uiTests"
 
     static var isRunningUITests: Bool {
         // If you want to run the app in Debug mode, but have it pretend that it

--- a/PRODUCTNAME/app/PRODUCTNAME/Utilities/ProcessInfo+Utilities.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Utilities/ProcessInfo+Utilities.swift
@@ -2,8 +2,8 @@
 //  ProcessInfo+Utilities.swift
 //  PRODUCTNAME
 //
-//  Created by Zev Eisenberg on 4/3/18.
-//  Copyright © 2018 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAME/Utilities/UserDefaults+Utilities.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Utilities/UserDefaults+Utilities.swift
@@ -2,8 +2,8 @@
 //  UserDefaults+Utilities.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 3/27/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/Payloads.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/Payloads.swift
@@ -2,8 +2,8 @@
 //  Payloads.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/3/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/TestClient.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/TestClient.swift
@@ -2,8 +2,8 @@
 //  TestClient.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 7/24/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/TestConstants.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/TestConstants.swift
@@ -2,8 +2,8 @@
 //  TestConstants.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/3/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/TestEndpoint.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/TestEndpoint.swift
@@ -2,8 +2,8 @@
 //  RandomEndpoint.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/3/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Alamofire

--- a/PRODUCTNAME/app/PRODUCTNAMETests/OAuth/APIClientTests.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/OAuth/APIClientTests.swift
@@ -2,8 +2,8 @@
 //  APIClientTests.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/3/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import OHHTTPStubs

--- a/PRODUCTNAME/app/PRODUCTNAMETests/OAuth/OAuthTests.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/OAuth/OAuthTests.swift
@@ -2,8 +2,8 @@
 //  OAuthTests.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/3/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import OHHTTPStubs

--- a/PRODUCTNAME/app/PRODUCTNAMETests/PRODUCTNAMETests.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/PRODUCTNAMETests.swift
@@ -2,8 +2,8 @@
 //  PRODUCTNAMETests.swift
 //  PRODUCTNAMETests
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import XCTest

--- a/PRODUCTNAME/app/Screenshots/Screenshots.swift
+++ b/PRODUCTNAME/app/Screenshots/Screenshots.swift
@@ -2,8 +2,8 @@
 //  Screenshots.swift
 //  Screenshots
 //
-//  Created by Zev Eisenberg on 4/3/18.
-//  Copyright © 2018 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import XCTest

--- a/PRODUCTNAME/app/Services/API/APIClient+PRODUCTNAME.swift
+++ b/PRODUCTNAME/app/Services/API/APIClient+PRODUCTNAME.swift
@@ -2,8 +2,8 @@
 //  APIClient+PRODUCTNAME.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 7/24/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/Services/API/APIClient.swift
+++ b/PRODUCTNAME/app/Services/API/APIClient.swift
@@ -2,8 +2,8 @@
 //  APIClient.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Alamofire

--- a/PRODUCTNAME/app/Services/API/APIConstants.swift
+++ b/PRODUCTNAME/app/Services/API/APIConstants.swift
@@ -2,8 +2,8 @@
 //  APIConstants.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/2/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 /// APIConstants that are used in multiple places

--- a/PRODUCTNAME/app/Services/API/APIEndpoint+Codable.swift
+++ b/PRODUCTNAME/app/Services/API/APIEndpoint+Codable.swift
@@ -2,8 +2,8 @@
 //  APIEndpoint+Codable.swift
 //  Services
 //
-//  Created by LEADDEVELOPER on 5/10/19.
-//  Copyright © 2019 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/Services/API/APIEndpoint+Logging.swift
+++ b/PRODUCTNAME/app/Services/API/APIEndpoint+Logging.swift
@@ -2,8 +2,8 @@
 //  APIEndpoint+Logging.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 7/24/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Swiftilities

--- a/PRODUCTNAME/app/Services/API/APIEndpoint.swift
+++ b/PRODUCTNAME/app/Services/API/APIEndpoint.swift
@@ -2,8 +2,8 @@
 //  APIEndpoint.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Alamofire

--- a/PRODUCTNAME/app/Services/API/APIEnvironment.swift
+++ b/PRODUCTNAME/app/Services/API/APIEnvironment.swift
@@ -2,8 +2,8 @@
 //  APIEnvironment.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 7/24/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/Services/API/APIError.swift
+++ b/PRODUCTNAME/app/Services/API/APIError.swift
@@ -2,8 +2,8 @@
 //  APIError.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 public enum APIError: Error {

--- a/PRODUCTNAME/app/Services/API/APISerialization.swift
+++ b/PRODUCTNAME/app/Services/API/APISerialization.swift
@@ -2,8 +2,8 @@
 //  APISerialization.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 4/16/17.
-//
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Alamofire

--- a/PRODUCTNAME/app/Services/API/APIValidation.swift
+++ b/PRODUCTNAME/app/Services/API/APIValidation.swift
@@ -2,8 +2,8 @@
 //  APIValidation.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 4/11/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Alamofire

--- a/PRODUCTNAME/app/Services/API/Alamofire+PRODUCTNAME.swift
+++ b/PRODUCTNAME/app/Services/API/Alamofire+PRODUCTNAME.swift
@@ -2,8 +2,8 @@
 //  Alamofire.Manager+PRODUCTNAME.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/3/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Alamofire

--- a/PRODUCTNAME/app/Services/API/OAuth.swift
+++ b/PRODUCTNAME/app/Services/API/OAuth.swift
@@ -2,8 +2,8 @@
 //  OauthEndpoint.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/2/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Alamofire

--- a/PRODUCTNAME/app/Services/BuildType.swift
+++ b/PRODUCTNAME/app/Services/BuildType.swift
@@ -2,8 +2,8 @@
 //  BuildType.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Foundation

--- a/PRODUCTNAME/app/Services/Services.h
+++ b/PRODUCTNAME/app/Services/Services.h
@@ -2,8 +2,8 @@
 //  Services.h
 //  Services
 //
-//  Created by Brian King on 10/25/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/PRODUCTNAME/app/Services/Utilities/Closures.swift
+++ b/PRODUCTNAME/app/Services/Utilities/Closures.swift
@@ -2,8 +2,8 @@
 //  Closures.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 4/5/17.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 public typealias VoidClosure = () -> Void

--- a/PRODUCTNAME/app/Services/Utilities/Formatters.swift
+++ b/PRODUCTNAME/app/Services/Utilities/Formatters.swift
@@ -2,8 +2,8 @@
 //  Formatters.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/1/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 public enum Formatters {

--- a/PRODUCTNAME/app/Services/Utilities/Keychain+Codable.swift
+++ b/PRODUCTNAME/app/Services/Utilities/Keychain+Codable.swift
@@ -2,8 +2,8 @@
 //  Keychain+Codable.swift
 //  PRODUCTNAME
 //
-//  Created by LEADDEVELOPER on 11/3/16.
-//  Copyright © 2017 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import KeychainAccess

--- a/PRODUCTNAME/app/Services/Utilities/RequestProtocol.swift
+++ b/PRODUCTNAME/app/Services/Utilities/RequestProtocol.swift
@@ -2,8 +2,8 @@
 //  RequestProtocol.swift
 //  Services
 //
-//  Created by LEADDEVELOPER on 5/10/19.
-//  Copyright © 2019 ORGANIZATION. All rights reserved.
+//  Created by LEADDEVELOPER on TODAYSDATE.
+//  Copyright © THISYEAR ORGANIZATION. All rights reserved.
 //
 
 import Alamofire

--- a/PRODUCTNAME/app/fastlane/Appfile
+++ b/PRODUCTNAME/app/fastlane/Appfile
@@ -1,4 +1,4 @@
 app_identifier "com.ORGANIZATION.PRODUCTNAME" # The bundle identifier of your app
-apple_id "LEADEMAIL"
+apple_id "APPLEID"
 
 team_id "TEAMID"  # Developer Portal Team ID

--- a/PRODUCTNAME/app/fastlane/Fastfile
+++ b/PRODUCTNAME/app/fastlane/Fastfile
@@ -105,7 +105,7 @@ platform :ios do
     # Getting artifact URLs from CircleCI
 
     # You must set up the CIRCLE_API_TOKEN manually using these instructions
-    # https://github.com/Raizlabs/ios-template/tree/master/PRODUCTNAME#danger
+    # https://github.com/Rightpoint/ios-template#danger
     token = ENV['CIRCLE_API_TOKEN']
     # These are already in the Circle environment
     # https://circleci.com/docs/2.0/env-vars/#build-specific-environment-variables
@@ -125,7 +125,7 @@ platform :ios do
         slack(message: "Screenshots are missing!", success: false)
       end
     else
-      slack(message: "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Raizlabs/circleci_artifact#getting-started) is not set, or not running on CircleCI.", success: false)
+      slack(message: "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Rightpoint/circleci_artifact#getting-started) is not set, or not running on CircleCI.", success: false)
     end
   end
 
@@ -135,7 +135,7 @@ platform :ios do
       teamID: "XRTVVR644Y",
       signingCertificate: "iPhone Distribution",
       provisioningProfiles: { "com.raizlabs.PRODUCTNAME.develop" => "Raizlabs Generic Enterprise Profile" }
-    })    
+    })
     hockey(public_identifier: 'ZZHOCKEY_DEVELOP_IDZZ')
     # upload_symbols_to_crashlytics(:api_token => 'ZZCRASHLYTICS_API_TOKEN_DEVELOPZZ')
     slack(message: "Successfully uploaded build #{build_number} to develop", success: true)
@@ -147,7 +147,7 @@ platform :ios do
       teamID: "XRTVVR644Y",
       signingCertificate: "iPhone Distribution",
       provisioningProfiles: { "com.raizlabs.PRODUCTNAME.sprint" => "Raizlabs Generic Enterprise Profile" }
-    })  
+    })
     hockey(public_identifier: 'ZZHOCKEY_SPRINT_IDZZ')
     # upload_symbols_to_crashlytics(:api_token => 'ZZCRASHLYTICS_API_TOKEN_SPRINTZZ')
     slack(message: "Successfully uploaded build #{build_number} to sprint", success: true)
@@ -159,7 +159,7 @@ platform :ios do
   #    teamID: "",
   #    signingCertificate: "iPhone Distribution",
   #    provisioningProfiles: { "" => "" }
-  #  })    
+  #  })
   #  pilot(
   #   distribute_external: false,
   #     skip_waiting_for_build_processing: true,

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
     "company_name": "Rightpoint",
     "bundle_identifier": "com.{{ cookiecutter.company_name | replace(' ', '-') | lower }}.{{ cookiecutter.project_name | replace(' ', '-') | lower }}",
     "lead_dev": "Your Name",
-    "lead_email": "{{ cookiecutter.lead_dev | replace(' ', '.') | lower }}@rightpoint.com",
+    "apple_id": "apple_id@rightpoint.com",
     "hockey_key": "Ask a tech lead for the Hockey Key or enter NO",
     "jira_key": "Specify the JIRA projectKey"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,9 @@
 {
     "project_name": "Project Name",
-    "company_name": "Raizlabs",
+    "company_name": "Rightpoint",
     "bundle_identifier": "com.{{ cookiecutter.company_name | replace(' ', '-') | lower }}.{{ cookiecutter.project_name | replace(' ', '-') | lower }}",
     "lead_dev": "Your Name",
-    "lead_email": "{{ cookiecutter.lead_dev | replace(' ', '.') | lower }}@raizlabs.com",
+    "lead_email": "{{ cookiecutter.lead_dev | replace(' ', '.') | lower }}@rightpoint.com",
     "hockey_key": "Ask a tech lead for the Hockey Key or enter NO",
     "jira_key": "Specify the JIRA projectKey"
 }

--- a/generate_template.sh
+++ b/generate_template.sh
@@ -90,7 +90,7 @@ function replace {
 replace "PRODUCTNAME" "{{ cookiecutter.project_name | replace(' ', '') }}"
 replace "ORGANIZATION" "{{ cookiecutter.company_name }}"
 replace "LEADDEVELOPER" "{{ cookiecutter.lead_dev }}"
-replace "LEADEMAIL" "{{ cookiecutter.lead_email }}"
+replace "APPLEID" "{{ cookiecutter.apple_id }}"
 replace "com.raizlabs.PRODUCTNAME" "{{ cookiecutter.bundle_identifier }}"
 replace "THISYEAR" "{% now 'utc', '%Y' %}"
 replace "TODAYSDATE" "{% now 'utc', '%D' %}"

--- a/generate_template.sh
+++ b/generate_template.sh
@@ -30,7 +30,7 @@ if [ ! -z "$OUTPUT_DIR" ] ; then
     cp -rf "$LOOKUP" "$OUTPUT_DIR/$LOOKUP"
     cp cookiecutter.json "$OUTPUT_DIR/"
     if [ "${SKIP_REGENERATION}" == "true" ] ; then
-        cp -rf "$EXPANDED" "$OUTPUT_DIR/$EXPANDED" 
+        cp -rf "$EXPANDED" "$OUTPUT_DIR/$EXPANDED"
     fi
     cd $OUTPUT_DIR
 fi
@@ -73,7 +73,7 @@ done
 # Do replacements
 function replace {
     grep -rl $1 ./PRODUCTNAME | while read FILE
-    do 
+    do
     NEWFILE=`echo $FILE | sed -e "s/${LOOKUP}/${EXPANDED}/g"`
         SED_CMD="LC_ALL=C sed -e \"s/$1/$2/g\" \"$NEWFILE\" > t1 && mv t1 \"$NEWFILE\""
         # Copy over incase the sed fails due to encoding
@@ -83,7 +83,7 @@ function replace {
         fi
         if [ "${SKIP_REGENERATION}" != "true" ] ; then
             eval $SED_CMD
-        fi        
+        fi
     done
 }
 
@@ -92,6 +92,10 @@ replace "ORGANIZATION" "{{ cookiecutter.company_name }}"
 replace "LEADDEVELOPER" "{{ cookiecutter.lead_dev }}"
 replace "LEADEMAIL" "{{ cookiecutter.lead_email }}"
 replace "com.raizlabs.PRODUCTNAME" "{{ cookiecutter.bundle_identifier }}"
+CURRENTYEAR="date +"%Y""
+replace "THISYEAR" "${CURRENTYEAR}"
+CURRENTDAY="date +"%Y""
+replace "TODAYSDATE" "${CURRENTDAY}"
 
 if [ "${SKIP_REGENERATION}" == "true" ] ; then
     echo "Dry run complete."
@@ -114,7 +118,7 @@ cookiecutter --no-input --overwrite-if-exists ./
 
 if [ "${SKIP_TESTS}" == "true" ] ; then
     echo "Skipping tests..."
-else    
+else
     echo "Running tests..."
 
     pushd "$TEST_OUTPUT_DIR/app"

--- a/generate_template.sh
+++ b/generate_template.sh
@@ -92,10 +92,8 @@ replace "ORGANIZATION" "{{ cookiecutter.company_name }}"
 replace "LEADDEVELOPER" "{{ cookiecutter.lead_dev }}"
 replace "LEADEMAIL" "{{ cookiecutter.lead_email }}"
 replace "com.raizlabs.PRODUCTNAME" "{{ cookiecutter.bundle_identifier }}"
-CURRENTYEAR="date +"%Y""
-replace "THISYEAR" "${CURRENTYEAR}"
-CURRENTDAY="date +"%Y""
-replace "TODAYSDATE" "${CURRENTDAY}"
+replace "THISYEAR" "{% now 'utc', '%Y' %}"
+replace "TODAYSDATE" "{% now 'utc', '%D' %}"
 
 if [ "${SKIP_REGENERATION}" == "true" ] ; then
     echo "Dry run complete."

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/Dangerfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/Dangerfile
@@ -40,7 +40,7 @@ swiftlint.lint_files inline_mode: true
 # Getting artifact URLs from CircleCI
 
 # You must set up the CIRCLE_API_TOKEN manually using these instructions
-# https://github.com/Raizlabs/ios-template/tree/master/{{ cookiecutter.project_name | replace(' ', '') }}#danger
+# https://github.com/Rightpoint/ios-template#danger
 token = ENV['CIRCLE_API_TOKEN']
 # These are already in the Circle environment
 # https://circleci.com/docs/2.0/env-vars/#build-specific-environment-variables
@@ -83,7 +83,7 @@ if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
     message "Screenshots in progress..."
   end
 else
-  warn "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Raizlabs/circleci_artifact#getting-started) is not set, or Danger is not running on CircleCI."
+  warn "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Rightpoint/circleci_artifact#getting-started) is not set, or Danger is not running on CircleCI."
 end
 
 # Test Reporting

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Screenshots/Screenshots.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Screenshots/Screenshots.swift
@@ -2,8 +2,8 @@
 //  Screenshots.swift
 //  Screenshots
 //
-//  Created by Zev Eisenberg on 4/3/18.
-//  Copyright © 2018 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import XCTest

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIClient+{{ cookiecutter.project_name | replace(' ', '') }}.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIClient+{{ cookiecutter.project_name | replace(' ', '') }}.swift
@@ -2,8 +2,8 @@
 //  APIClient+{{ cookiecutter.project_name | replace(' ', '') }}.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 7/24/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIClient.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIClient.swift
@@ -2,8 +2,8 @@
 //  APIClient.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Alamofire

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIConstants.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIConstants.swift
@@ -2,8 +2,8 @@
 //  APIConstants.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/2/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 /// APIConstants that are used in multiple places

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIEndpoint+Codable.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIEndpoint+Codable.swift
@@ -2,8 +2,8 @@
 //  APIEndpoint+Codable.swift
 //  Services
 //
-//  Created by {{ cookiecutter.lead_dev }} on 5/10/19.
-//  Copyright © 2019 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIEndpoint+Logging.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIEndpoint+Logging.swift
@@ -2,8 +2,8 @@
 //  APIEndpoint+Logging.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 7/24/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Swiftilities

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIEndpoint.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIEndpoint.swift
@@ -2,8 +2,8 @@
 //  APIEndpoint.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Alamofire

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIEnvironment.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIEnvironment.swift
@@ -2,8 +2,8 @@
 //  APIEnvironment.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 7/24/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIError.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIError.swift
@@ -2,8 +2,8 @@
 //  APIError.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 public enum APIError: Error {

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APISerialization.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APISerialization.swift
@@ -2,8 +2,8 @@
 //  APISerialization.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 4/16/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Alamofire

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIValidation.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/APIValidation.swift
@@ -2,8 +2,8 @@
 //  APIValidation.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 4/11/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Alamofire

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/Alamofire+{{ cookiecutter.project_name | replace(' ', '') }}.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/Alamofire+{{ cookiecutter.project_name | replace(' ', '') }}.swift
@@ -2,8 +2,8 @@
 //  Alamofire.Manager+{{ cookiecutter.project_name | replace(' ', '') }}.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/3/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Alamofire

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/OAuth.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/API/OAuth.swift
@@ -2,8 +2,8 @@
 //  OauthEndpoint.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/2/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Alamofire

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/BuildType.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/BuildType.swift
@@ -2,8 +2,8 @@
 //  BuildType.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Services.h
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Services.h
@@ -2,8 +2,8 @@
 //  Services.h
 //  Services
 //
-//  Created by Brian King on 10/25/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Utilities/Closures.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Utilities/Closures.swift
@@ -2,8 +2,8 @@
 //  Closures.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 4/5/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 public typealias VoidClosure = () -> Void

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Utilities/Formatters.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Utilities/Formatters.swift
@@ -2,8 +2,8 @@
 //  Formatters.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 public enum Formatters {

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Utilities/Keychain+Codable.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Utilities/Keychain+Codable.swift
@@ -2,8 +2,8 @@
 //  Keychain+Codable.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/3/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import KeychainAccess

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Utilities/RequestProtocol.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/Services/Utilities/RequestProtocol.swift
@@ -2,8 +2,8 @@
 //  RequestProtocol.swift
 //  Services
 //
-//  Created by {{ cookiecutter.lead_dev }} on 5/10/19.
-//  Copyright © 2019 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Alamofire

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Appfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Appfile
@@ -1,4 +1,4 @@
 app_identifier "com.{{ cookiecutter.company_name }}.{{ cookiecutter.project_name | replace(' ', '') }}" # The bundle identifier of your app
-apple_id "{{ cookiecutter.lead_email }}"
+apple_id "{{ cookiecutter.apple_id }}"
 
 team_id "TEAMID"  # Developer Portal Team ID

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
@@ -105,7 +105,7 @@ platform :ios do
     # Getting artifact URLs from CircleCI
 
     # You must set up the CIRCLE_API_TOKEN manually using these instructions
-    # https://github.com/Raizlabs/ios-template/tree/master/{{ cookiecutter.project_name | replace(' ', '') }}#danger
+    # https://github.com/Rightpoint/ios-template#danger
     token = ENV['CIRCLE_API_TOKEN']
     # These are already in the Circle environment
     # https://circleci.com/docs/2.0/env-vars/#build-specific-environment-variables
@@ -125,7 +125,7 @@ platform :ios do
         slack(message: "Screenshots are missing!", success: false)
       end
     else
-      slack(message: "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Raizlabs/circleci_artifact#getting-started) is not set, or not running on CircleCI.", success: false)
+      slack(message: "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Rightpoint/circleci_artifact#getting-started) is not set, or not running on CircleCI.", success: false)
     end
   end
 
@@ -135,7 +135,7 @@ platform :ios do
       teamID: "XRTVVR644Y",
       signingCertificate: "iPhone Distribution",
       provisioningProfiles: { "com.raizlabs.{{ cookiecutter.project_name | replace(' ', '') }}.develop" => "Raizlabs Generic Enterprise Profile" }
-    })    
+    })
     hockey(public_identifier: 'ZZHOCKEY_DEVELOP_IDZZ')
     # upload_symbols_to_crashlytics(:api_token => 'ZZCRASHLYTICS_API_TOKEN_DEVELOPZZ')
     slack(message: "Successfully uploaded build #{build_number} to develop", success: true)
@@ -147,7 +147,7 @@ platform :ios do
       teamID: "XRTVVR644Y",
       signingCertificate: "iPhone Distribution",
       provisioningProfiles: { "com.raizlabs.{{ cookiecutter.project_name | replace(' ', '') }}.sprint" => "Raizlabs Generic Enterprise Profile" }
-    })  
+    })
     hockey(public_identifier: 'ZZHOCKEY_SPRINT_IDZZ')
     # upload_symbols_to_crashlytics(:api_token => 'ZZCRASHLYTICS_API_TOKEN_SPRINTZZ')
     slack(message: "Successfully uploaded build #{build_number} to sprint", success: true)
@@ -159,7 +159,7 @@ platform :ios do
   #    teamID: "",
   #    signingCertificate: "iPhone Distribution",
   #    provisioningProfiles: { "" => "" }
-  #  })    
+  #  })
   #  pilot(
   #   distribute_external: false,
   #     skip_waiting_for_build_processing: true,

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppDelegate.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppDelegate.swift
@@ -2,8 +2,8 @@
 //  AppDelegate.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/Analytics/Analytics.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/Analytics/Analytics.swift
@@ -2,8 +2,8 @@
 //  Analytics.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 1/13/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }} All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/Analytics/AnalyticsPageNames.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/Analytics/AnalyticsPageNames.swift
@@ -2,8 +2,8 @@
 //  AnalyticsPageNames.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 1/13/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }} All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/Analytics/GoogleAnalytics.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/Analytics/GoogleAnalytics.swift
@@ -2,8 +2,8 @@
 //  GoogleAnalytics.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 1/13/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }} All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/AnalyticsConfiguration.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/AnalyticsConfiguration.swift
@@ -2,8 +2,8 @@
 //  AnalyticsConfiguration.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Swiftilities

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/AppLifecycle.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/AppLifecycle.swift
@@ -2,8 +2,8 @@
 //  AppLifecycleConfigurable.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/CrashlyticsConfiguration.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/CrashlyticsConfiguration.swift
@@ -2,8 +2,8 @@
 //  CrashlyticsConfiguration.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Fabric

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/DebugMenuConfiguration.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/DebugMenuConfiguration.swift
@@ -2,8 +2,8 @@
 //  DebugMenuConfiguration.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/InstabugConfiguration.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/InstabugConfiguration.swift
@@ -2,8 +2,8 @@
 //  InstabugConfiguration.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Instabug

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/LoggingConfiguration.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/LoggingConfiguration.swift
@@ -2,8 +2,8 @@
 //  LoggingConfiguration.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/StatusBarConfiguration.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/StatusBarConfiguration.swift
@@ -2,8 +2,8 @@
 //  StatusBarConfiguration.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by Zev Eisenberg on 4/3/18.
-//  Copyright © 2018 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 #if targetEnvironment(simulator) && DEBUG

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Appearance/Appearance.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Appearance/Appearance.swift
@@ -2,8 +2,8 @@
 //  Appearance.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Appearance/StringStyle+{{ cookiecutter.project_name | replace(' ', '') }}.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Appearance/StringStyle+{{ cookiecutter.project_name | replace(' ', '') }}.swift
@@ -2,8 +2,8 @@
 //  StringStyle+{{ cookiecutter.project_name | replace(' ', '') }}.swft
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Debug/DebugMenu.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Debug/DebugMenu.swift
@@ -2,8 +2,8 @@
 //  DebugMenu.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 10/25/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Swiftilities

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Debug/DebugMenuViewController.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Debug/DebugMenuViewController.swift
@@ -2,8 +2,8 @@
 //  DebugMenuViewController.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 10/26/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Debug/DebugTextStyleViewController.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/Debug/DebugTextStyleViewController.swift
@@ -2,8 +2,8 @@
 //  DebugTextStyleViewController.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 10/25/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Behaviors/HideBackButtonTextBehavior.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Behaviors/HideBackButtonTextBehavior.swift
@@ -2,8 +2,8 @@
 //  HideBackButtonTextBehavior.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 7/7/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Swiftilities

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Behaviors/ModalDismissBehavior.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Behaviors/ModalDismissBehavior.swift
@@ -2,8 +2,8 @@
 //  ModalDismissBehavior.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 7/7/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Swiftilities

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Protocols/Actionable.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Protocols/Actionable.swift
@@ -2,8 +2,8 @@
 //  Actionable.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/8/18.
-//  Copyright © 2018 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 protocol Actionable: class {

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/SimpleTableCellItem.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/SimpleTableCellItem.swift
@@ -2,8 +2,8 @@
 //  SimpleTableCellItem.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 10/26/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/TableCellItem.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/TableCellItem.swift
@@ -2,8 +2,8 @@
 //  TableCellItem.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 7/10/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/TableDataSource.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/TableDataSource.swift
@@ -2,8 +2,8 @@
 //  TableDataSource.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 6/6/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Anchorage

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/TableSection.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/TableSection.swift
@@ -2,8 +2,8 @@
 //  TableSection.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 6/6/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/TableViewCellRepresentable.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/TableViewCellRepresentable.swift
@@ -2,8 +2,8 @@
 //  TableViewCellRepresentable.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 6/6/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/ViewRepresentable.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Representable/ViewRepresentable.swift
@@ -2,10 +2,10 @@
 //  ViewRepresentable.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 6/5/17.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
-//
 public protocol ViewRepresentable: AnyViewRepresentable {
     associatedtype View: UIView
     func makeView() -> View

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Views/ControlContainable.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Views/ControlContainable.swift
@@ -2,8 +2,8 @@
 //  ControlContainable.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 7/7/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Views/TableViewContainerCell.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Components/Views/TableViewContainerCell.swift
@@ -2,8 +2,8 @@
 //  TableViewContainerCell.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 6/6/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Anchorage

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/AppCoordinator.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/AppCoordinator.swift
@@ -2,8 +2,8 @@
 //  AppCoordinator.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/24/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/AuthCoordinator.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/AuthCoordinator.swift
@@ -2,8 +2,8 @@
 //  AuthCoordinator.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/24/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/ContentCoordinator.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/ContentCoordinator.swift
@@ -2,8 +2,8 @@
 //  ContentCoordinator.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/27/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/Coordinator.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/Coordinator.swift
@@ -2,8 +2,8 @@
 //  Coordinator.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/24/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/OnboardingCoordinator.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/OnboardingCoordinator.swift
@@ -2,8 +2,8 @@
 //  OnboardingCoordinator.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/27/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/SignInCoordinator.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Coordinators/SignInCoordinator.swift
@@ -2,8 +2,8 @@
 //  SignInCoordinator.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/27/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Extensions/UIColor+Extensions.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Extensions/UIColor+Extensions.swift
@@ -2,8 +2,8 @@
 //  UIColor+Extensions.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/29/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/Color.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/Color.swift
@@ -2,8 +2,8 @@
 //  Color.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/29/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 enum Color {

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/AppStore.xcconfig
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/AppStore.xcconfig
@@ -2,8 +2,8 @@
 //  AppStore.xcconfig
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 #include "{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Raizlabs-Account.xcconfig"

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Debug.xcconfig
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Debug.xcconfig
@@ -2,8 +2,8 @@
 //  Debug.xcconfig
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 #include "{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Raizlabs-Account.xcconfig"

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Develop.xcconfig
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Develop.xcconfig
@@ -2,8 +2,8 @@
 //  Develop.xcconfig
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 #include "{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Raizlabs-Account.xcconfig"

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Global.xcconfig
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Global.xcconfig
@@ -2,8 +2,8 @@
 //  Global.xcconfig
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 BUILD_NUMBER=1

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Raizlabs-Account.xcconfig
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Raizlabs-Account.xcconfig
@@ -2,8 +2,8 @@
 //  Raizlabs-Account.xcconfig
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 // Any keys that should be available to the application should be added here, and then

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Sprint.xcconfig
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Sprint.xcconfig
@@ -2,8 +2,8 @@
 //  Sprint.xcconfig
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 #include "{{ cookiecutter.project_name | replace(' ', '') }}/Resources/xcconfig/Raizlabs-Account.xcconfig"

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/{{ cookiecutter.project_name | replace(' ', '') }}-Bridging-Header.h
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Resources/{{ cookiecutter.project_name | replace(' ', '') }}-Bridging-Header.h
@@ -2,8 +2,8 @@
 //  {{ cookiecutter.project_name | replace(' ', '') }}-Bridging-Header.h
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/20/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 // EXTERNAL

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Screens/ContentTabBarViewController.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Screens/ContentTabBarViewController.swift
@@ -2,8 +2,8 @@
 //  ContentTabBarViewController.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/20/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import UIKit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Screens/Onboarding/OnboardingPageViewController.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Screens/Onboarding/OnboardingPageViewController.swift
@@ -2,8 +2,8 @@
 //  OnboardingPageViewController.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/29/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Anchorage

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Screens/Onboarding/OnboardingSamplePageViewController.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Screens/Onboarding/OnboardingSamplePageViewController.swift
@@ -2,8 +2,8 @@
 //  OnboardingSamplePageViewController.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/29/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Anchorage

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Screens/Onboarding/OnboardingSamplePageViewModel.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Screens/Onboarding/OnboardingSamplePageViewModel.swift
@@ -2,8 +2,8 @@
 //  OnboardingSamplePageViewModel.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by Connor Neville on 4/5/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 struct OnboardingSamplePageViewModel {

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Utilities/ProcessInfo+Utilities.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Utilities/ProcessInfo+Utilities.swift
@@ -2,8 +2,8 @@
 //  ProcessInfo+Utilities.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by Zev Eisenberg on 4/3/18.
-//  Copyright © 2018 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Utilities/ProcessInfo+Utilities.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Utilities/ProcessInfo+Utilities.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension ProcessInfo {
 
-    static let uiTestsKey = "com.raizlabs.uiTests"
+    static let uiTestsKey = "com.rightpoint.uiTests"
 
     static var isRunningUITests: Bool {
         // If you want to run the app in Debug mode, but have it pretend that it

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Utilities/UserDefaults+Utilities.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Utilities/UserDefaults+Utilities.swift
@@ -2,8 +2,8 @@
 //  UserDefaults+Utilities.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 3/27/17.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/Payloads.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/Payloads.swift
@@ -2,8 +2,8 @@
 //  Payloads.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/3/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/TestClient.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/TestClient.swift
@@ -2,8 +2,8 @@
 //  TestClient.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 7/24/17.
-//
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/TestConstants.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/TestConstants.swift
@@ -2,8 +2,8 @@
 //  TestConstants.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/3/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Foundation

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/TestEndpoint.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/TestEndpoint.swift
@@ -2,8 +2,8 @@
 //  RandomEndpoint.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/3/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import Alamofire

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/OAuth/APIClientTests.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/OAuth/APIClientTests.swift
@@ -2,8 +2,8 @@
 //  APIClientTests.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/3/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import OHHTTPStubs

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/OAuth/OAuthTests.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/OAuth/OAuthTests.swift
@@ -2,8 +2,8 @@
 //  OAuthTests.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/3/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import OHHTTPStubs

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/{{ cookiecutter.project_name | replace(' ', '') }}Tests.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/{{ cookiecutter.project_name | replace(' ', '') }}Tests.swift
@@ -2,8 +2,8 @@
 //  {{ cookiecutter.project_name | replace(' ', '') }}Tests.swift
 //  {{ cookiecutter.project_name | replace(' ', '') }}Tests
 //
-//  Created by {{ cookiecutter.lead_dev }} on 11/1/16.
-//  Copyright © 2017 {{ cookiecutter.company_name }}. All rights reserved.
+//  Created by {{ cookiecutter.lead_dev }} on {% now 'utc', '%D' %}.
+//  Copyright © {% now 'utc', '%Y' %} {{ cookiecutter.company_name }}. All rights reserved.
 //
 
 import XCTest


### PR DESCRIPTION
fixes 3 issues:
• Issue 114 - fixes copyright to "Rightpoint" in root `LICENSE` file
• Issue 140 - sets today's date in file headers ("on" date and copyright year)
• Updates cookiecutter defaults in JSON to use Rightpoint.

Sorry for the big PR, but it's mostly conforming file header comments.